### PR TITLE
fix: `options` arg should be optional

### DIFF
--- a/lib/millify.ts
+++ b/lib/millify.ts
@@ -35,7 +35,7 @@ function* divider(value: number, base: number): IterableIterator<number> {
  * @param {number} value - Number to convert
  * @param {Options} options
  */
-function Millify(value: number, options: Options): string {
+function Millify(value: number, options: Options = {}): string {
   // Override default options with supplied ones
   const opts: Options = { ...defaultOptions, ...options };
 


### PR DESCRIPTION
According to doc & code, I think this arg should be optional.