### PR TITLE
Fix `MillifyOptions` imports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 /**
  * Options used to configure Millify.
  */
-interface MillifyOptions {
+export interface MillifyOptions {
   /**
    * The number of significant figures.
    */

--- a/lib/millify.ts
+++ b/lib/millify.ts
@@ -1,3 +1,4 @@
+import type { MillifyOptions } from "..";
 import { defaultOptions } from "./options";
 import { parseValue, roundTo } from "./utils";
 

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -1,3 +1,5 @@
+import type { MillifyOptions } from "..";
+
 /**
  * Default options for Millify.
  */


### PR DESCRIPTION
The `MillifyOptions` are defined in the root level `index.ts` but are not imported in the files inside `lib`, which are using them. When using the package in a project, the Typescript compiler fails, because "`MillifyOptions` is not defined".

This PR adds the missing imports.