### PR TITLE
feat: use locale decimal separator as default

### DIFF
--- a/lib/millify.ts
+++ b/lib/millify.ts
@@ -1,5 +1,5 @@
 import { defaultOptions, MillifyOptions } from "./options";
-import { parseValue, roundTo } from "./utils";
+import { parseValue, roundTo, getDefaultDecimalSeparator } from "./utils";
 
 // Most commonly used digit grouping base.
 const DIGIT_GROUPING_BASE = 1000;
@@ -96,9 +96,10 @@ function millify(value: number, options?: Partial<MillifyOptions>): string {
   const space = opts.space ? " " : "";
 
   // Replace decimal mark if desired.
+  const defaultDecimalSeparator = getDefaultDecimalSeaparator();
   const formatted = rounded
     .toString()
-    .replace(defaultOptions.decimalSeparator, opts.decimalSeparator);
+    .replace(defaultDecimalSeparator, opts.decimalSeparator);
 
   return `${prefix}${formatted}${space}${suffix}`;
 }

--- a/lib/millify.ts
+++ b/lib/millify.ts
@@ -75,7 +75,7 @@ function millify(value: number, options?: Partial<MillifyOptions>): string {
   // a corresponding unit. Returning anything else is ambiguous.
   const unitIndexOutOfRange = unitIndex >= opts.units.length;
   if (unitIndexOutOfRange) {
-    return value.toString();
+    return value.toLocaleString();
   }
 
   // Round decimal up to desired precision.
@@ -97,9 +97,10 @@ function millify(value: number, options?: Partial<MillifyOptions>): string {
 
   // Replace decimal mark if desired.
   const defaultDecimalSeparator = getDefaultDecimalSeaparator();
-  const formatted = rounded
-    .toString()
-    .replace(defaultDecimalSeparator, opts.decimalSeparator);
+  let formatted = rounded.toLocaleString();
+  if (opts.decimalSeparator) {
+    formatted = formatted.replace(defaultDecimalSeparator, opts.decimalSeparator);
+  }
 
   return `${prefix}${formatted}${space}${suffix}`;
 }

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -7,9 +7,9 @@ export interface MillifyOptions {
    */
   precision: number;
   /**
-   * The type of decimal marker (e.g. period ".").
+   * The type of decimal marker (e.g. period "."") or *null* to use locale default.
    */
-  decimalSeparator: string;
+  decimalSeparator: string | null;
   /**
    * Convert units to lower case.
    */
@@ -28,7 +28,7 @@ export interface MillifyOptions {
  * Default options for Millify.
  */
 export const defaultOptions: MillifyOptions = {
-  decimalSeparator: ".",
+  decimalSeparator: null,
   lowercase: false,
   precision: 1,
   space: false,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -32,7 +32,7 @@ export function roundTo(value: number, precision: number): number {
 /**
  * Calculates the default decimal separator given the current locale
  */
-export function getDefaultDecimalSeaparator(): string {
+export function getDefaultDecimalSeparator(): string {
   const value = 1.1;
   const result = value.toLocaleString().substring(1, 2);
   return result;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -28,3 +28,14 @@ export function roundTo(value: number, precision: number): number {
   }
   return parseFloat(value.toFixed(precision));
 }
+
+/**
+ * Calculates the default decimal separator given the current locale
+ */
+export function getDefaultDecimalSeaparator(): string {
+  const numberWithDecimalSeparator = 1.1;
+  return Intl.NumberFormat(locale)
+      .formatToParts(numberWithDecimalSeparator)
+      .find(part => part.type === 'decimal')
+      .value;
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -34,7 +34,7 @@ export function roundTo(value: number, precision: number): number {
  */
 export function getDefaultDecimalSeaparator(): string {
   const numberWithDecimalSeparator = 1.1;
-  return Intl.NumberFormat(locale)
+  return Intl.NumberFormat()
       .formatToParts(numberWithDecimalSeparator)
       .find(part => part.type === 'decimal')
       .value;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -33,9 +33,7 @@ export function roundTo(value: number, precision: number): number {
  * Calculates the default decimal separator given the current locale
  */
 export function getDefaultDecimalSeaparator(): string {
-  const numberWithDecimalSeparator = 1.1;
-  return Intl.NumberFormat()
-      .formatToParts(numberWithDecimalSeparator)
-      .find(part => part.type === 'decimal')
-      .value;
+  const value = 1.1;
+  const result = value.toLocaleString().substring(1, 2);
+  return result;
 }


### PR DESCRIPTION
Thanks for such a great package!

In this PR I'm adding the logic of detecting the default decimal separator given the current locale, instead of simply using `.` as the default value.